### PR TITLE
fix!: Remove unsupported exports from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,6 @@
   "name": "@tipccjs/tipcc-api-types",
   "version": "1.0.7",
   "description": "tip.cc API typings that are kept up to date for use in API related applications.",
-  "main": "lib/v0.js",
-  "types": "lib/v0.d.ts",
   "scripts": {
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prettify": "prettier --write .",


### PR DESCRIPTION
The (default) exports removed are usually specified like this when using the `"exports"` field:
```
"exports": {
  ".": {
    "require": "./dir/main.js",
    "import": "./dir/main.js",
    "types": "./dir/main.d.ts"
  }
}
```

However, using this approach for this package is unnecessary and can cause problems later down the line.
As new versions of the tip.cc API are released, users of this package will need to specify they want to use the new version. This is likely the safest approach, instead of a dynamic default import.

This is a breaking change (of something that shouldn't be implemented in the first place), and tipccjs/tipcc.js will be updated with a hotfix accordingly.